### PR TITLE
docs: use `Object`, not `Instance`

### DIFF
--- a/docs/Closures/hookmetamethod.md
+++ b/docs/Closures/hookmetamethod.md
@@ -7,7 +7,7 @@
 `#!luau hookmetamethod` takes any Luau object that can have a metatable, and attempts to hook the specified metamethod of the object. Internally, it essentially uses [`#!luau hookfunction`](./hookfunction.md) to hook specific metamethods.
 
 ```luau
-function hookmetamethod(object: { [any]: any } | Instance | userdata, metamethodName: string, hook: (...any) -> (...any)): (...any) -> (...any)
+function hookmetamethod(object: { [any]: any } | Object | userdata, metamethodName: string, hook: (...any) -> (...any)): (...any) -> (...any)
 ```
 
 ## Parameters

--- a/docs/Drawing/README.md
+++ b/docs/Drawing/README.md
@@ -2,7 +2,7 @@
 
 The `#!luau Drawing` class represents a renderable 2D object that appears on the user's screen. Every specific drawing type (e.g. `Circle`, `Text`, `Line`) inherits from this base and extends it with shape-specific properties.
 
-Drawing objects are ***not*** instances - they are client-only graphical primitives that do not interact with the 3D world and must be managed manually.
+Drawing objects are ***not*** instances or engine objects - they are client-only graphical primitives defined by the implementation that do not interact with the 3D world and must be managed manually.
 
 ---
 
@@ -34,7 +34,7 @@ function Drawing.new(type: string): Drawing
 
     ![Definition of the word "Transparency"](./assets/transparency.png)
 
-    In sUNC, we follow the correct meaning of the word. `#!luau Transparency` represents true transparency, where `#!luau 0` means fully opaque and `#!luau 1` means fully **transparent** (see-through). This also aligns with how Roblox handles their transparency property on some instances (e.g. Part, Frame, etc).
+    In sUNC, we follow the correct meaning of the word. `#!luau Transparency` represents true transparency, where `#!luau 0` means fully opaque and `#!luau 1` means fully **transparent** (see-through). This also aligns with how Roblox handles their transparency property on some objects (e.g. Part, Frame, etc).
 
 All drawing object types inherit the following fields:
 

--- a/docs/Instances/getcallbackvalue.md
+++ b/docs/Instances/getcallbackvalue.md
@@ -1,19 +1,19 @@
 # `getcallbackvalue`
 
-`#!luau getcallbackvalue` retrieves the **assigned callback property** on an [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance), such as [`#!luau OnInvoke`](https://create.roblox.com/docs/reference/engine/classes/BindableFunction#OnInvoke).
+`#!luau getcallbackvalue` retrieves the **assigned callback property** on an [`#!luau Object`](https://create.roblox.com/docs/reference/engine/classes/Object), such as [`#!luau OnInvoke`](https://create.roblox.com/docs/reference/engine/classes/BindableFunction#OnInvoke).
 
 Normally, these properties are **write-only**, meaning you can assign a function to them but cannot read them back. This function bypasses that limitation and exposes the function directly.
 
 ```luau
-function getcallbackvalue(object: Instance, property: string): any | nil
+function getcallbackvalue(object: Object, property: string): any | nil
 ```
 
 ## Parameters
 
-| Parameter         | Description                                                                                                                |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `#!luau object`   | The [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance) that owns the callback property. |
-| `#!luau property` | The name of the callback property to retrieve.                                                                             |
+| Parameter         | Description                                                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `#!luau object`   | The [`#!luau Object`](https://create.roblox.com/docs/reference/engine/classes/Object) that owns the callback property. |
+| `#!luau property` | The name of the callback property to retrieve.                                                                         |
 
 ---
 

--- a/docs/Metatable/README.md
+++ b/docs/Metatable/README.md
@@ -10,7 +10,7 @@ This library is especially useful when trying to modify or access hidden things 
 
 A [**metatable**](https://create.roblox.com/docs/luau/metatables) in Luau is a hidden table that can change the behavior of another table. Metatables allow you to define custom behaviors like operator overloading, default values, or interception of table reads and writes using special fields like [`#!luau __index`](https://create.roblox.com/docs/luau/metatables#metamethods) or [`#!luau __newindex`](https://create.roblox.com/docs/luau/metatables#metamethods).
 
-In Roblox, this is useful for exposing metatables of Roblox Instances so that they can be leveraged for hooking or other modifications.
+In Roblox, this is useful for exposing metatables of [Objects](https://create.roblox.com/docs/reference/engine/classes/Object) so that they can be leveraged for hooking or other modifications.
 
 ---
 

--- a/docs/Reflection/README.md
+++ b/docs/Reflection/README.md
@@ -1,6 +1,6 @@
 # Reflection
 
-The **Reflection** library allows access to and manipulation of hidden or non-scriptable properties of [Instances](https://create.roblox.com/docs/reference/engine/classes/Instance) and internal execution context. It is primarily used to bypass standard Luau restrictions in controlled environments.
+The **Reflection** library allows access to and manipulation of hidden or non-scriptable properties of [Objects](https://create.roblox.com/docs/reference/engine/classes/Object) and internal execution context. It is primarily used to bypass standard Luau restrictions in controlled environments.
 
 ---
 
@@ -8,8 +8,8 @@ The **Reflection** library allows access to and manipulation of hidden or non-sc
 
 With the Reflection library, you can:
 
-- **Read** hidden instance properties using [`#!luau gethiddenproperty`](./gethiddenproperty.md)
-- **Write** to hidden instance properties with [`#!luau sethiddenproperty`](./sethiddenproperty.md)
+- **Read** hidden object properties using [`#!luau gethiddenproperty`](./gethiddenproperty.md)
+- **Write** to hidden object properties with [`#!luau sethiddenproperty`](./sethiddenproperty.md)
 - **Toggle and check** scriptability of properties using [`#!luau setscriptable`](./setscriptable.md) and [`#!luau isscriptable`](./isscriptable.md).
 - **Elevate** thread permissions with [`#!luau setthreadidentity`](./setthreadidentity.md)
 - **Query** the current thread's permission level with [`#!luau getthreadidentity`](./getthreadidentity.md)

--- a/docs/Reflection/gethiddenproperty.md
+++ b/docs/Reflection/gethiddenproperty.md
@@ -4,20 +4,20 @@
 
     Some executors implement this function using [`#!luau setscriptable`](./setscriptable.md), which is limited and/or detectable.
 
-`#!luau gethiddenproperty` retrieves the value of a hidden or non-scriptable property (e.g. `BinaryString`, `SharedString`, `SystemAddress`) from a given [`Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance), even if it would normally throw an error when accessed directly.
+`#!luau gethiddenproperty` retrieves the value of a hidden or non-scriptable property (e.g. `BinaryString`, `SharedString`, `SystemAddress`) from a given [`Object`](https://create.roblox.com/docs/reference/engine/classes/Object), even if it would normally throw an error when accessed directly.
 
 This function also returns whether the accessed property was hidden.
 
 ```luau
-function gethiddenproperty(instance: Instance, property_name: string): (any, boolean)
+function gethiddenproperty(object: Object, property_name: string): (any, boolean)
 ```
 
 ## Parameters
 
-| Parameter              | Description                                                                                                      |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `#!luau instance`      | The [instance](https://create.roblox.com/docs/reference/engine/classes/Instance) containing the hidden property. |
-| `#!luau property_name` | The name of the property to access.                                                                              |
+| Parameter              | Description                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `#!luau object`        | The [Object](https://create.roblox.com/docs/reference/engine/classes/Object) containing the hidden property. |
+| `#!luau property_name` | The name of the property to access.                                                                          |
 
 ---
 

--- a/docs/Reflection/isscriptable.md
+++ b/docs/Reflection/isscriptable.md
@@ -1,21 +1,21 @@
 # `isscriptable`
 
-`#!luau isscriptable` returns whether the given property of an [`Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance) is scriptable (i.e. it does not have the `#!luau notscriptable` tag).
+`#!luau isscriptable` returns whether the given property of an [`Object`](https://create.roblox.com/docs/reference/engine/classes/Object) is scriptable (i.e. it does not have the `#!luau notscriptable` tag).
 
 If it returns `#!luau true`, then the property is scriptable and can be indexed normally, and vice versa.
 
 If it returns `#!luau nil`, then the property provided does not exist.
 
 ```luau
-function isscriptable(object: Instance, property: string): boolean | nil
+function isscriptable(object: Object, property: string): boolean | nil
 ```
 
 ## Parameters
 
-| Parameter         | Description                                                                                                       |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `#!luau object`   | The [`Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance) that owns the target property. |
-| `#!luau property` | The name of the property to check.                                                                                |
+| Parameter         | Description                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `#!luau object`   | The [`Object`](https://create.roblox.com/docs/reference/engine/classes/Object) that owns the target property. |
+| `#!luau property` | The name of the property to check.                                                                            |
 
 ---
 

--- a/docs/Reflection/sethiddenproperty.md
+++ b/docs/Reflection/sethiddenproperty.md
@@ -4,21 +4,21 @@
 
     Some executors implement this function using [`#!luau setscriptable`](./setscriptable.md), which is limited and/or detectable.
 
-`#!luau sethiddenproperty` assigns a value to a hidden or non-scriptable property of an [`Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance), even if that property is inaccessible.
+`#!luau sethiddenproperty` assigns a value to a hidden or non-scriptable property of an [`Object`](https://create.roblox.com/docs/reference/engine/classes/Object), even if that property is inaccessible.
 
 It returns `#!luau true` if the property is hidden and was successfully written to, or `#!luau false` if the property wasn't hidden but was still updated.
 
 ```luau
-function sethiddenproperty(instance: Instance, property_name: string, property_value: any): boolean
+function sethiddenproperty(object: Object, property_name: string, property_value: any): boolean
 ```
 
 ## Parameters
 
-| Parameter               | Description                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `#!luau instance`       | The [instance](https://create.roblox.com/docs/reference/engine/classes/Instance) that owns the target property. |
-| `#!luau property_name`  | The name of the property to update.                                                                             |
-| `#!luau property_value` | The new value to assign to the property.                                                                        |
+| Parameter               | Description                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `#!luau object`         | The [Object](https://create.roblox.com/docs/reference/engine/classes/Object) that owns the target property. |
+| `#!luau property_name`  | The name of the property to update.                                                                         |
+| `#!luau property_value` | The new value to assign to the property.                                                                    |
 
 ---
 

--- a/docs/Reflection/setscriptable.md
+++ b/docs/Reflection/setscriptable.md
@@ -8,19 +8,19 @@
 
     Not all hidden properties can be obtained using this function.
 
-`#!luau setscriptable` toggles the scriptability of a hidden or non-scriptable property on an [`Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance). When a property is made scriptable, it can be accessed or assigned through standard indexing.
+`#!luau setscriptable` toggles the scriptability of a hidden or non-scriptable property on an [`Object`](https://create.roblox.com/docs/reference/engine/classes/Object). When a property is made scriptable, it can be accessed or assigned through standard indexing.
 
 ```luau
-function setscriptable(instance: Instance, property_name: string, state: boolean): boolean | nil
+function setscriptable(object: Object, property_name: string, state: boolean): boolean | nil
 ```
 
 ## Parameters
 
-| Parameter              | Description                                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `#!luau instance`      | The [Instance](https://create.roblox.com/docs/reference/engine/classes/Instance) that owns the target property. |
-| `#!luau property_name` | The name of the property to make scriptable or un-scriptable.                                                   |
-| `#!luau state`         | Whether to enable (`#!luau true`) or disable (`#!luau false`) scriptability.                                    |
+| Parameter              | Description                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `#!luau object`        | The [Object](https://create.roblox.com/docs/reference/engine/classes/Object) that owns the target property. |
+| `#!luau property_name` | The name of the property to make scriptable or un-scriptable.                                               |
+| `#!luau state`         | Whether to enable (`#!luau true`) or disable (`#!luau false`) scriptability.                                |
 
 ---
 

--- a/docs/Scripts/README.md
+++ b/docs/Scripts/README.md
@@ -12,7 +12,7 @@ With the Scripts library, you can:
 - **Get the bytecode hash** of a script using [`#!luau getscripthash`](./getscripthash.md)
 - **Create a new closure based off of the script's bytecode** using [`#!luau getscriptclosure`](./getscriptclosure.md)
 - **Access script environments** with [`#!luau getsenv`](./getsenv.md)
-- **Enumerate script instances** using [`#!luau getscripts`](./getscripts.md) and [`#!luau getrunningscripts`](./getrunningscripts.md)
+- **Enumerate script objects** using [`#!luau getscripts`](./getscripts.md) and [`#!luau getrunningscripts`](./getrunningscripts.md)
 - **List loaded modules** via [`#!luau getloadedmodules`](./getloadedmodules.md)
 - **Determine the current script** executing via [`#!luau getcallingscript`](./getcallingscript.md)
 - **Resolve the script associated with a thread** using [`#!luau getscriptfromthread`](./getscriptfromthread.md)

--- a/docs/Scripts/getloadedmodules.md
+++ b/docs/Scripts/getloadedmodules.md
@@ -2,10 +2,10 @@
 
 !!! warning "Returns only loaded modules"
 
-    This function **only** returns [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances that have already been loaded using [`#!luau require`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require).  
+    This function **only** returns [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects that have already been loaded using [`#!luau require`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require).  
     It does **not** return all [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects in the game - for that, use [`#!luau getscripts`](./getscripts.md).
 
-`#!luau getloadedmodules` returns a list of all [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances that have been **loaded** (e.g. [`#!luau require`'d](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require)).
+`#!luau getloadedmodules` returns a list of all [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects that have been **loaded** (e.g. [`#!luau require`'d](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require)).
 
 This includes only modules with completed executions, and **excludes** any modules that errored or haven't been required yet.
 

--- a/docs/Scripts/getrunningscripts.md
+++ b/docs/Scripts/getrunningscripts.md
@@ -6,7 +6,7 @@
     
     This also includes scripts whose [`#!luau script` global variable](https://create.roblox.com/docs/reference/engine/globals/RobloxGlobals#script) is set to `#!luau nil` or reassigned - i.e. `#!luau getrunningscripts` should still include said scripts.
 
-`#!luau getrunningscripts` returns a list of **all running scripts** in the caller's global state. This includes [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances - excluding [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
+`#!luau getrunningscripts` returns a list of **all running scripts** in the caller's global state. This includes [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects - excluding [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
 
 ```luau
 function getrunningscripts(): { BaseScript | ModuleScript }

--- a/docs/Scripts/getscriptbytecode.md
+++ b/docs/Scripts/getscriptbytecode.md
@@ -12,9 +12,9 @@ function getscriptbytecode(script: BaseScript | ModuleScript): string | nil
 
 ## Parameters
 
-| Parameter       | Description                                        |
-| --------------- | -------------------------------------------------- |
-| `#!luau script` | The script instance to retrieve the bytecode from. |
+| Parameter       | Description                                      |
+| --------------- | ------------------------------------------------ |
+| `#!luau script` | The script object to retrieve the bytecode from. |
 
 ---
 

--- a/docs/Scripts/getscriptclosure.md
+++ b/docs/Scripts/getscriptclosure.md
@@ -18,9 +18,9 @@ function getscriptclosure(script: BaseScript | ModuleScript): (...any) -> (...an
 
 ## Parameters
 
-| Parameter       | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `#!luau script` | The script instance to convert into a function. |
+| Parameter       | Description                                   |
+| --------------- | --------------------------------------------- |
+| `#!luau script` | The script object to convert into a function. |
 
 ---
 

--- a/docs/Scripts/getscripthash.md
+++ b/docs/Scripts/getscripthash.md
@@ -15,9 +15,9 @@ function getscripthash(script: BaseScript | ModuleScript): string | nil
 
 ## Parameters
 
-| Parameter       | Description                                                                                                                                                                                    |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `#!luau script` | The [BaseScript](https://create.roblox.com/docs/reference/engine/classes/BaseScript) or [ModuleScript](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instance to hash. |
+| Parameter       | Description                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#!luau script` | The [BaseScript](https://create.roblox.com/docs/reference/engine/classes/BaseScript) or [ModuleScript](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) object to hash. |
 
 ---
 

--- a/docs/Scripts/getscripts.md
+++ b/docs/Scripts/getscripts.md
@@ -1,6 +1,6 @@
 # `getscripts`
 
-`#!luau getscripts` returns a list of **all [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances** present.
+`#!luau getscripts` returns a list of **all [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects** present.
 
 This function excludes [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
 
@@ -18,7 +18,7 @@ function getscripts(): { BaseScript | ModuleScript }
 
 ## Example
 
-```luau title="Locating a known script instance" linenums="1"
+```luau title="Locating a known script object" linenums="1"
 local dummy_script = Instance.new("LocalScript")
 dummy_script.Name = "TestScript"
 

--- a/docs/Scripts/getsenv.md
+++ b/docs/Scripts/getsenv.md
@@ -14,9 +14,9 @@ function getsenv(script: BaseScript | ModuleScript): { [any]: any } | nil
 
 ## Parameters
 
-| Parameter       | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `#!luau script` | The script instance whose environment should be retrieved. |
+| Parameter       | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `#!luau script` | The script object whose environment should be retrieved. |
 
 ---
 


### PR DESCRIPTION
This will be enforced by the actual v3 script.

NOTE: that functions in the Instance library CANNOT accept/return Objects instead of Instances as objects are not cached.